### PR TITLE
Content proposal

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,10 +41,15 @@ icon = "fab fa-github"
 title = "GitHub"
 url = "https://github.com/zaolin/padsec"
 
-#[[params.socialLinks]]
-#icon = "fas fa-envelope"
-#title = "Email"
-#url = "mailto:example@example.com"
+[[params.socialLinks]]
+icon = "fab fa-youtube"
+title = "YouTube"
+url = "https://www.youtube.com/channel/UCVL5qGL2cg4JYYbskW2fp5Q"
+
+[[params.socialLinks]]
+icon = "fas fa-envelope"
+title = "Email"
+url = "mailto:padsec@immu.ne"
 
 [menu]
 

--- a/config.toml
+++ b/config.toml
@@ -32,19 +32,19 @@ logo = "images/rice.svg"
 # * Academicons <https://jpswalsh.github.io/academicons> ('ai ai-')
 
 [[params.socialLinks]]
+icon = "fab fa-twitter"
+title = "Twitter"
+url = "https://twitter.com/padseconf"
+
+[[params.socialLinks]]
 icon = "fab fa-github"
 title = "GitHub"
-url = "https://github.com/joeroe/risotto"
+url = "https://github.com/zaolin/padsec"
 
-[[params.socialLinks]]
-icon = "fas fa-envelope"
-title = "Email"
-url = "mailto:example@example.com"
-
-[[params.socialLinks]]
-icon = "ai ai-orcid"
-title = "ORCID"
-url = "https://orcid.org/0000-0001-2345-6789"
+#[[params.socialLinks]]
+#icon = "fas fa-envelope"
+#title = "Email"
+#url = "mailto:example@example.com"
 
 [menu]
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,10 @@
+The next Practical \& Defensive Security Conference (PADSEC) pops-up virtually
+at the Open Source Firmware Conference (OSFC).
+
+Important links:
+- CFP: https://talks.osfc.io/osfc2021/cfp
+
+Important dates:
+- Submission deadline: October 3, 2021
+- Notification: October 15, 2021
+- Conference: November 30 - December 1, 2021

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,6 +3,7 @@ at the Open Source Firmware Conference (OSFC).
 
 Important links:
 - CFP: https://talks.osfc.io/osfc2021/cfp
+- Registration: https://tickets.osfc.io/
 
 Important dates:
 - Submission deadline: October 3, 2021

--- a/content/about.md
+++ b/content/about.md
@@ -1,3 +1,6 @@
+---
+title: About
+---
 The Practical And Defensive SEcurity Conference (PADSEC) is an emerging
 community that aims to understand real-world security problems and their
 technical solutions.  PADSEC is intended as a pop-up conference that _pops-up_

--- a/content/events.md
+++ b/content/events.md
@@ -1,0 +1,11 @@
+---
+title: Events
+---
+- 2nd PADSEC:
+_virtual pop-up event at OSFC_,
+November 30 - December 1 (2021).
+[CFP](https://talks.osfc.io/osfc2021/cfp)
+- 1st PADSEC:
+_virtual event_,
+May 7 (2021).
+[Program](https://hopin.com/events/padsec#schedule)

--- a/content/media.md
+++ b/content/media.md
@@ -1,0 +1,4 @@
+---
+title: Media
+---
+Coming soon!

--- a/content/videos.md
+++ b/content/videos.md
@@ -1,0 +1,4 @@
+---
+title: Videos
+---
+Coming soon!


### PR DESCRIPTION
Added a landing page that gives important information about next PADSEC event. This was less work than moving a refactored about.md to the front page. I think it is natural that you'd click the 'about' page or 'cfp' link if you want to know more.

Also added a list of upcoming/past events. We might want to refactor that in the future, but perhaps good enough for now.